### PR TITLE
Update PR CI and update README

### DIFF
--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -13,7 +13,6 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8]
       fail-fast: true
-    if: ${{ !contains(github.event.head_commit.message, '!skipci') }}
     steps:
       # By default, actions/checkout will check out the PR branch as if it was merged so that the final version can be tested
       - name: Checkout merged code to test

--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ Visit the [official documentation](https://mcadminbot.readthedocs.io/en/latest/)
 * [ ] Implement more Minecraft commands
 * [ ] Write tests and implement automated testing of branches
 * [x] Implement proper semantic versioning and CI/CD
+
+## Notes
+
+* Any commits or merges into the `master` branch need to follow the [Angular commit message guidelines](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular).


### PR DESCRIPTION
Remove check for PR workflow that allows for skipping CI. Update README to include note about message format for commits/merges to master.